### PR TITLE
support for JetBrains' IDEs (WebStorm, IDEA 14 CE) on OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Supported editors:
 - [Sublime Text](http://www.sublimetext.com/)
 - [Atom Editor](https://atom.io/)
 - [Visual Studio Code](https://code.visualstudio.com/)
+- [WebStorm](https://www.jetbrains.com/webstorm/)
+- [IDEA 14 Community Edition](https://www.jetbrains.com/idea/download/)
 
 But you also can use any other editor that is able to open files from command line.
 
@@ -61,7 +63,7 @@ If editor setup was successful `configure` method returns an interface with sing
 
 Type: `String`
 
-Values: `sublime`, `atom`, `code`
+Values: `sublime`, `atom`, `code`, `webstorm`, `idea14ce`
 
 Default: *not set*
 
@@ -72,6 +74,8 @@ Supported editors:
 - `sublime` – Sublime Text
 - `atom` – Atom Editor
 - `code` – Visual Studio Code
+- `webstorm` – WebStorm
+- `idea14ce` – IDEA 14 CE
 
 #### cmd
 
@@ -152,7 +156,7 @@ Options:
 
       --cmd <command>      Command to open file
       --debug              Debug errors
-  -e, --editor <editor>    Editor: atom, code, sublime
+  -e, --editor <editor>    Editor: atom, code, sublime, webstorm, idea14ce
   -f, --file <filename>    File to open
   -h, --help               Output usage information
   -v, --version            Output version

--- a/lib/editors/idea14ce.js
+++ b/lib/editors/idea14ce.js
@@ -1,0 +1,14 @@
+var ide = require('./jetbrains-ide');
+
+var detect = ide.detect({
+  appFolder: 'IntelliJ IDEA 14 CE',
+  name: 'IDEA 14 CE',
+  executable: 'idea'
+});
+var open = require('../open').detectAndOpenFactory(detect, ide.settings);
+
+module.exports = {
+  settings: ide.settings,
+  detect: detect,
+  open: open
+};

--- a/lib/editors/index.js
+++ b/lib/editors/index.js
@@ -1,5 +1,7 @@
 module.exports = {
   atom: require('./atom'),
   code: require('./code'),
-  sublime: require('./sublime')
+  sublime: require('./sublime'),
+  webstorm: require('./webstorm'),
+  idea14ce: require('./idea14ce')
 };

--- a/lib/editors/jetbrains-ide.js
+++ b/lib/editors/jetbrains-ide.js
@@ -1,0 +1,17 @@
+var settings = {
+  pattern: '{filename} --line {line}'
+};
+
+var detect = function(ide) {
+  return require('../detect').lazy(ide.name, [], '', {
+    darwin: [
+      '/Applications/' + ide.appFolder + '.app/Contents/MacOS/' + ide.executable
+    ]
+    // TODO win
+  });
+};
+
+module.exports = {
+  settings: settings,
+  detect: detect
+};

--- a/lib/editors/webstorm.js
+++ b/lib/editors/webstorm.js
@@ -1,0 +1,14 @@
+var ide = require('./jetbrains-ide');
+
+var detect = ide.detect({
+  appFolder: 'WebStorm',
+  name: 'WebStorm IDE',
+  executable: 'webstorm'
+});
+var open = require('../open').detectAndOpenFactory(detect, ide.settings);
+
+module.exports = {
+  settings: ide.settings,
+  detect: detect,
+  open: open
+};


### PR DESCRIPTION
I don't have any copy of Windows to check paths to IDE. Also I've added support only for IDEs I have on my laptop but adding support for other IDEs should be trivial enough.
