### PR TITLE
Add support jetbrains products on windows platform

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+end_of_line = lf
+
+[*.js]
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/lib/editors/jetbrains-ide.js
+++ b/lib/editors/jetbrains-ide.js
@@ -1,13 +1,34 @@
 var settings = {
-  pattern: '{filename} --line {line}'
+  pattern: '{projectPath} --line {line} {filename}'
 };
+
+var fs = require('fs');
+var path = require('path');
+
+var winDirs = (function() {
+  var jetbrainsFolder = 'c:/Program Files (x86)/JetBrains/';
+
+  if (!fs.existsSync(jetbrainsFolder)) {
+    return [];
+  }
+
+  return fs.readdirSync(jetbrainsFolder)
+    .map(function(name) {
+      return path.join(jetbrainsFolder, name);
+    })
+    .filter(function(path) {
+      return fs.statSync(path).isDirectory();
+    });
+})();
 
 var detect = function(ide) {
   return require('../detect').lazy(ide.name, [], '', {
     darwin: [
       '/Applications/' + ide.appFolder + '.app/Contents/MacOS/' + ide.executable
-    ]
-    // TODO win
+    ],
+    win32: winDirs.map(function(dir){
+      return dir + '/bin/' + ide.executable + '.exe';
+    })
   });
 };
 

--- a/lib/open.js
+++ b/lib/open.js
@@ -9,6 +9,7 @@ function makeArguments(filename, settings) {
   var info = extractFilename(filename);
   var pattern = settings.pattern || '';
   var values = {
+    projectPath: process.env.PROJECT_PATH || process.PWD || process.cwd(),
     line: info.line + number(settings.line, 1),
     column: info.column + number(settings.column, 1)
   };


### PR DESCRIPTION
Accordenly jetbrains the [documentation](https://www.jetbrains.com/webstorm/help/working-with-webstorm-features-from-command-line.html) you need to specify the path to the project for opening file. I'm not sure it's a good decision, because it expand current contract. Maybe you can offer more apprictiate solution?
