### PR TITLE
Vim for linux and use a single vim instance

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "semistandard"
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "semistandard"
+  "extends": "semistandard",
+  "rules": {
+    "space-before-function-paren": ["error", "never"]
+  }
 }

--- a/README.md
+++ b/README.md
@@ -188,6 +188,21 @@ Options:
   -v, --version            Output the version
 ```
 
+## Development
+
+It's very simple playing with `oe`. Just try the tests before contributing:
+
+```
+git clone https://github.com/lahmatiy/open-in-editor
+npm install -d
+npm test
+```
+
+## Contributing
+
+Pull requests and stars are always welcome.
+For bugs and feature requests, please [create an issue](https://github.com/lahmatiy/open-in-editor).
+
 ## Related projects
 
 - [express-open-in-editor](https://github.com/lahmatiy/express-open-in-editor) – `Express` extension to open files from browser.

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ It's very simple playing with `oe`. Just try the tests before contributing:
 
 ```
 git clone https://github.com/lahmatiy/open-in-editor
-npm install -d
+npm install
 npm test
 ```
 

--- a/lib/check.js
+++ b/lib/check.js
@@ -8,8 +8,8 @@ function checkCommand(cmd, name, args) {
   }
 
   return new Promise(function(resolve, reject) {
-    var command = shell(cmd, args).toString();
-    exec(command.cmd, function(err, output) {
+    var command = String(shell(cmd).concat(shell.parse(args)));
+    exec(command, function(err, output) {
       if (err || output.indexOf(name) !== 0) {
         reject(err);
       } else {

--- a/lib/check.js
+++ b/lib/check.js
@@ -1,6 +1,6 @@
 var exec = require('child_process').exec;
 var fs = require('fs');
-var quote = require('./utils').quote;
+var shell = require('./editors/common/shell');
 
 function checkCommand(cmd, name, args) {
   if (!args) {
@@ -8,7 +8,8 @@ function checkCommand(cmd, name, args) {
   }
 
   return new Promise(function(resolve, reject) {
-    exec(cmd + ' ' + args, function(err, output) {
+    var command = shell(cmd, args).toString();
+    exec(command.cmd, function(err, output) {
       if (err || output.indexOf(name) !== 0) {
         reject(err);
       } else {

--- a/lib/editors/common/shell.js
+++ b/lib/editors/common/shell.js
@@ -2,59 +2,59 @@ var shellQuote = require('shell-quote');
 var shellEscape = require('command-join');
 var assign = require('../../utils').assign;
 
-function shell(...args) {
+function shell (...args) {
   return new ShellCommand(args);
 }
 
-function ShellCommand(args) {
+function ShellCommand (args) {
   this._args = ShellCommand.parseArgs(args);
   this._params = {};
 }
 
-ShellCommand.isShellCommand = function isShellCommand(value) {
+ShellCommand.isShellCommand = function isShellCommand (value) {
   return value.constructor === ShellCommand;
 };
 
-ShellCommand.parse = function parse(value) {
+ShellCommand.parse = function parse (value) {
   return ShellCommand.isShellCommand(value) ? value : shellQuote.parse('' + value);
 };
 
-ShellCommand.parseArgs = function parseArgs(args) {
+ShellCommand.parseArgs = function parseArgs (args) {
   return Array.prototype.concat(...(args.map(ShellCommand.parse)));
-}
+};
 
-ShellCommand.quote = function quote(args) {
+ShellCommand.quote = function quote (args) {
   return shellEscape(args.map(function (arg) {
     return arg && arg.op ? arg.op : arg;
   }));
-}
+};
 
-ShellCommand.prototype.toString = function toString() {
+ShellCommand.prototype.toString = function toString () {
   return ShellCommand.quote(this._args.map(this._quoteArgs.bind(this)));
 };
 
-ShellCommand.prototype.withParams = function withParams(params) {
+ShellCommand.prototype.withParams = function withParams (params) {
   return assign(shell([]), this, {
     _params: assign({}, this._params, params)
   });
 };
 
-ShellCommand.prototype.concat = function concat(...args) {
+ShellCommand.prototype.concat = function concat (...args) {
   return assign(shell([]), this, {
-    _args: this._args.concat(ShellCommand.parseArgs(args).reduce(function(dest, src) {
+    _args: this._args.concat(ShellCommand.parseArgs(args).reduce(function (dest, src) {
       return dest.concat(ShellCommand.isShellCommand(src) ? src._args : [src]);
     }, [])),
     _params: assign.apply(null, [{}, this._params].concat(args.map(function (arg) {
-      return ShellCommand.isShellCommand(arg) ? arg._params : {}
+      return ShellCommand.isShellCommand(arg) ? arg._params : {};
     })))
   });
 };
 
-ShellCommand.prototype._quoteArgs = function _quoteArgs(value) {
+ShellCommand.prototype._quoteArgs = function _quoteArgs (value) {
   return ShellCommand.isShellCommand(value) ? value.withParams(this._params).toString() : this._replaceParams(value);
 };
 
-ShellCommand.prototype._replaceParams = function _replaceParams(value) {
+ShellCommand.prototype._replaceParams = function _replaceParams (value) {
   return value.replace ? value.replace(/\{([^}]+)\}/g, function (whole, name) {
     return this._params[name] ? this._params[name] : whole;
   }.bind(this)) : value;

--- a/lib/editors/common/shell.js
+++ b/lib/editors/common/shell.js
@@ -1,0 +1,63 @@
+var shellQuote = require('shell-quote');
+var shellEscape = require('command-join');
+var assign = require('../../utils').assign;
+
+function shell(...args) {
+  return new ShellCommand(args);
+}
+
+function ShellCommand(args) {
+  this._args = ShellCommand.parseArgs(args);
+  this._params = {};
+}
+
+ShellCommand.isShellCommand = function isShellCommand(value) {
+  return value.constructor === ShellCommand;
+};
+
+ShellCommand.parse = function parse(value) {
+  return ShellCommand.isShellCommand(value) ? value : shellQuote.parse('' + value);
+};
+
+ShellCommand.parseArgs = function parseArgs(args) {
+  return Array.prototype.concat(...(args.map(ShellCommand.parse)));
+}
+
+ShellCommand.quote = function quote(args) {
+  return shellEscape(args.map(function (arg) {
+    return arg && arg.op ? arg.op : arg;
+  }));
+}
+
+ShellCommand.prototype.toString = function toString() {
+  return ShellCommand.quote(this._args.map(this._quoteArgs.bind(this)));
+};
+
+ShellCommand.prototype.withParams = function withParams(params) {
+  return assign(shell([]), this, {
+    _params: assign({}, this._params, params)
+  });
+};
+
+ShellCommand.prototype.concat = function concat(...args) {
+  return assign(shell([]), this, {
+    _args: this._args.concat(ShellCommand.parseArgs(args).reduce(function(dest, src) {
+      return dest.concat(ShellCommand.isShellCommand(src) ? src._args : [src]);
+    }, [])),
+    _params: assign.apply(null, [{}, this._params].concat(args.map(function (arg) {
+      return ShellCommand.isShellCommand(arg) ? arg._params : {}
+    })))
+  });
+};
+
+ShellCommand.prototype._quoteArgs = function _quoteArgs(value) {
+  return ShellCommand.isShellCommand(value) ? value.withParams(this._params).toString() : this._replaceParams(value);
+};
+
+ShellCommand.prototype._replaceParams = function _replaceParams(value) {
+  return value.replace ? value.replace(/\{([^}]+)\}/g, function (whole, name) {
+    return this._params[name] ? this._params[name] : whole;
+  }.bind(this)) : value;
+};
+
+module.exports = shell;

--- a/lib/editors/common/shell.js
+++ b/lib/editors/common/shell.js
@@ -26,65 +26,64 @@ var assign = require('../../utils').assign;
  *
  * Arguments are variable number of strings or shell objects
  */
-function shell(...args) {
-  return new ShellCommand(args);
+function shell() {
+  return new ShellCommand(Array.prototype.slice.call(arguments));
+}
+
+function replaceParams(params, value) {
+  return value.replace ? value.replace(/\{([^}]+)\}/g, function(whole, name) {
+    return params[name] ? params[name] : whole;
+  }) : value;
 }
 
 function ShellCommand(args) {
-  this._args = ShellCommand.parse(args);
-  this._params = {};
+  this.args = Array.isArray(args) ? ShellCommand.parse(args) : [];
+  this.params = {};
 }
 
 ShellCommand.isShellCommand = function isShellCommand(value) {
   return value.constructor === ShellCommand;
 };
 
-ShellCommand.createEmpty = function createEmpty() {
-  return new ShellCommand([]);
-};
-
 ShellCommand.parse = function parse(args) {
-  var parseArg = function parse(value) {
-    return ShellCommand.isShellCommand(value) ? value : shellQuote.parse('' + value);
-  };
-  return Array.prototype.concat(...(args.map(parseArg)));
+  return args.reduce(function(result, value) {
+    return result.concat(ShellCommand.isShellCommand(value) ? value : shellQuote.parse(String(value)));
+  }, []);
 };
 
 ShellCommand.quote = function quote(args) {
-  return shellEscape(args.map(function(arg) {
-    return arg && arg.op ? arg.op : arg;
-  }));
+  return shellEscape(args);
 };
 
-ShellCommand.prototype.concat = function concat(...args) {
-  return assign(ShellCommand.createEmpty(), this, {
-    _args: this._args.concat(ShellCommand.parse(args).reduce(function(dest, src) {
-      return dest.concat(ShellCommand.isShellCommand(src) ? src._args : [src]);
-    }, [])),
-    _params: assign.apply(null, [{}, this._params].concat(args.map(function(arg) {
-      return ShellCommand.isShellCommand(arg) ? arg._params : {};
-    })))
-  });
+ShellCommand.prototype.clone = function clone() {
+  var command = new ShellCommand();
+  command.args = this.args.slice();
+  command.params = assign({}, this.params);
+  return command;
+};
+
+ShellCommand.prototype.concat = function concat() {
+  var args = Array.prototype.slice.call(arguments);
+  var command = this.clone();
+  command.args = command.args.concat(ShellCommand.parse(args).reduce(function(result, value) {
+    return result.concat(ShellCommand.isShellCommand(value) ? value.args : [value]);
+  }, []));
+  command.params = assign.apply(null, [command.params].concat(args.map(function(value) {
+    return ShellCommand.isShellCommand(value) ? value.params : {};
+  })));
+  return command;
 };
 
 ShellCommand.prototype.toString = function toString() {
-  return ShellCommand.quote(this._args.map(this._quoteArgs.bind(this)));
+  return ShellCommand.quote(this.args.map(function(value) {
+    return ShellCommand.isShellCommand(value) ? value.withParams(this.params).toString() : replaceParams(this.params, value);
+  }, this));
 };
 
 ShellCommand.prototype.withParams = function withParams(params) {
-  return assign(ShellCommand.createEmpty(), this, {
-    _params: assign({}, this._params, params)
+  return assign(new ShellCommand(), this, {
+    params: assign({}, this.params, params)
   });
-};
-
-ShellCommand.prototype._quoteArgs = function _quoteArgs(value) {
-  return ShellCommand.isShellCommand(value) ? value.withParams(this._params).toString() : this._replaceParams(value);
-};
-
-ShellCommand.prototype._replaceParams = function _replaceParams(value) {
-  return value.replace ? value.replace(/\{([^}]+)\}/g, function(whole, name) {
-    return this._params[name] ? this._params[name] : whole;
-  }.bind(this)) : value;
 };
 
 module.exports = shell;

--- a/lib/editors/common/shell.js
+++ b/lib/editors/common/shell.js
@@ -2,12 +2,36 @@ var shellQuote = require('shell-quote');
 var shellEscape = require('command-join');
 var assign = require('../../utils').assign;
 
+/**
+ * Build a shell command from arguments.
+ *
+ * It correctly escapes the arguments when it's converted to a string.
+ *
+ * Example:
+ *
+ *    shell('vim', 'the code.txt').toString() -> "vim 'the code.txt'"
+ *
+ * API:
+ *
+ *    shell('ls -l')
+ *    shell('ls', '-l')
+ *    shell('sh -c', shell('ls -l'))
+ *
+ * It also supports an argument parameters. It could be useful if it's needed to use some
+ * variables in the command and be ensured what the escaping is correctly applied to them values.
+ *
+ * Example:
+ *    shell('ls -l {dir}').withParams({dir: '/root'})
+ *    shell('sh -c', shell('ls -l {dir}')).withParams({dir: '/root'})
+ *
+ * Arguments are variable number of strings or shell objects
+ */
 function shell(...args) {
   return new ShellCommand(args);
 }
 
 function ShellCommand(args) {
-  this._args = ShellCommand.parseArgs(args);
+  this._args = ShellCommand.parse(args);
   this._params = {};
 }
 
@@ -15,12 +39,15 @@ ShellCommand.isShellCommand = function isShellCommand(value) {
   return value.constructor === ShellCommand;
 };
 
-ShellCommand.parse = function parse(value) {
-  return ShellCommand.isShellCommand(value) ? value : shellQuote.parse('' + value);
+ShellCommand.createEmpty = function createEmpty() {
+  return new ShellCommand([]);
 };
 
-ShellCommand.parseArgs = function parseArgs(args) {
-  return Array.prototype.concat(...(args.map(ShellCommand.parse)));
+ShellCommand.parse = function parse(args) {
+  var parseArg = function parse(value) {
+    return ShellCommand.isShellCommand(value) ? value : shellQuote.parse('' + value);
+  };
+  return Array.prototype.concat(...(args.map(parseArg)));
 };
 
 ShellCommand.quote = function quote(args) {
@@ -29,24 +56,24 @@ ShellCommand.quote = function quote(args) {
   }));
 };
 
-ShellCommand.prototype.toString = function toString() {
-  return ShellCommand.quote(this._args.map(this._quoteArgs.bind(this)));
-};
-
-ShellCommand.prototype.withParams = function withParams(params) {
-  return assign(shell([]), this, {
-    _params: assign({}, this._params, params)
-  });
-};
-
 ShellCommand.prototype.concat = function concat(...args) {
-  return assign(shell([]), this, {
-    _args: this._args.concat(ShellCommand.parseArgs(args).reduce(function(dest, src) {
+  return assign(ShellCommand.createEmpty(), this, {
+    _args: this._args.concat(ShellCommand.parse(args).reduce(function(dest, src) {
       return dest.concat(ShellCommand.isShellCommand(src) ? src._args : [src]);
     }, [])),
     _params: assign.apply(null, [{}, this._params].concat(args.map(function(arg) {
       return ShellCommand.isShellCommand(arg) ? arg._params : {};
     })))
+  });
+};
+
+ShellCommand.prototype.toString = function toString() {
+  return ShellCommand.quote(this._args.map(this._quoteArgs.bind(this)));
+};
+
+ShellCommand.prototype.withParams = function withParams(params) {
+  return assign(ShellCommand.createEmpty(), this, {
+    _params: assign({}, this._params, params)
   });
 };
 

--- a/lib/editors/common/shell.js
+++ b/lib/editors/common/shell.js
@@ -13,22 +13,29 @@ var assign = require('../../utils').assign;
  *
  * API:
  *
- *    shell('ls -l')
+ *    shell('ls')
  *    shell('ls', '-l')
- *    shell('sh -c', shell('ls -l'))
+ *    shell.parse('sh -c')
+ *    shell.parse('sh -c').concat(shell.parse('ls -l'))
  *
  * It also supports an argument parameters. It could be useful if it's needed to use some
  * variables in the command and be ensured what the escaping is correctly applied to them values.
  *
  * Example:
- *    shell('ls -l {dir}').withParams({dir: '/root'})
- *    shell('sh -c', shell('ls -l {dir}')).withParams({dir: '/root'})
+ *    shell.parse('ls -l {dir}').withParams({dir: '/root'})
+ *    shell.parse('sh -c', shell.parse('ls -l {dir}')).withParams({dir: '/root'})
  *
  * Arguments are variable number of strings or shell objects
  */
 function shell() {
   return new ShellCommand(Array.prototype.slice.call(arguments));
 }
+
+function parse() {
+  return new ShellCommand(ShellCommand.parse(Array.prototype.slice.call(arguments)));
+}
+
+shell.parse = parse;
 
 function replaceParams(params, value) {
   return value.replace ? value.replace(/\{([^}]+)\}/g, function(whole, name) {
@@ -37,7 +44,7 @@ function replaceParams(params, value) {
 }
 
 function ShellCommand(args) {
-  this.args = Array.isArray(args) ? ShellCommand.parse(args) : [];
+  this.args = Array.isArray(args) ? args : [];
   this.params = {};
 }
 
@@ -52,7 +59,7 @@ ShellCommand.parse = function parse(args) {
 };
 
 ShellCommand.quote = function quote(args) {
-  return shellEscape(args);
+  return shellEscape(args.map(String));
 };
 
 ShellCommand.prototype.clone = function clone() {
@@ -65,25 +72,26 @@ ShellCommand.prototype.clone = function clone() {
 ShellCommand.prototype.concat = function concat() {
   var args = Array.prototype.slice.call(arguments);
   var command = this.clone();
-  command.args = command.args.concat(ShellCommand.parse(args).reduce(function(result, value) {
+  command.args = command.args.concat(args.reduce(function(result, value) {
     return result.concat(ShellCommand.isShellCommand(value) ? value.args : [value]);
   }, []));
   command.params = assign.apply(null, [command.params].concat(args.map(function(value) {
     return ShellCommand.isShellCommand(value) ? value.params : {};
   })));
+
   return command;
 };
 
 ShellCommand.prototype.toString = function toString() {
   return ShellCommand.quote(this.args.map(function(value) {
-    return ShellCommand.isShellCommand(value) ? value.withParams(this.params).toString() : replaceParams(this.params, value);
+    return ShellCommand.isShellCommand(value) ? String(value.withParams(this.params)) : replaceParams(this.params, value);
   }, this));
 };
 
 ShellCommand.prototype.withParams = function withParams(params) {
-  return assign(new ShellCommand(), this, {
-    params: assign({}, this.params, params)
-  });
+  var command = this.clone();
+  assign(command.params, params);
+  return command;
 };
 
 module.exports = shell;

--- a/lib/editors/common/shell.js
+++ b/lib/editors/common/shell.js
@@ -2,60 +2,60 @@ var shellQuote = require('shell-quote');
 var shellEscape = require('command-join');
 var assign = require('../../utils').assign;
 
-function shell (...args) {
+function shell(...args) {
   return new ShellCommand(args);
 }
 
-function ShellCommand (args) {
+function ShellCommand(args) {
   this._args = ShellCommand.parseArgs(args);
   this._params = {};
 }
 
-ShellCommand.isShellCommand = function isShellCommand (value) {
+ShellCommand.isShellCommand = function isShellCommand(value) {
   return value.constructor === ShellCommand;
 };
 
-ShellCommand.parse = function parse (value) {
+ShellCommand.parse = function parse(value) {
   return ShellCommand.isShellCommand(value) ? value : shellQuote.parse('' + value);
 };
 
-ShellCommand.parseArgs = function parseArgs (args) {
+ShellCommand.parseArgs = function parseArgs(args) {
   return Array.prototype.concat(...(args.map(ShellCommand.parse)));
 };
 
-ShellCommand.quote = function quote (args) {
-  return shellEscape(args.map(function (arg) {
+ShellCommand.quote = function quote(args) {
+  return shellEscape(args.map(function(arg) {
     return arg && arg.op ? arg.op : arg;
   }));
 };
 
-ShellCommand.prototype.toString = function toString () {
+ShellCommand.prototype.toString = function toString() {
   return ShellCommand.quote(this._args.map(this._quoteArgs.bind(this)));
 };
 
-ShellCommand.prototype.withParams = function withParams (params) {
+ShellCommand.prototype.withParams = function withParams(params) {
   return assign(shell([]), this, {
     _params: assign({}, this._params, params)
   });
 };
 
-ShellCommand.prototype.concat = function concat (...args) {
+ShellCommand.prototype.concat = function concat(...args) {
   return assign(shell([]), this, {
-    _args: this._args.concat(ShellCommand.parseArgs(args).reduce(function (dest, src) {
+    _args: this._args.concat(ShellCommand.parseArgs(args).reduce(function(dest, src) {
       return dest.concat(ShellCommand.isShellCommand(src) ? src._args : [src]);
     }, [])),
-    _params: assign.apply(null, [{}, this._params].concat(args.map(function (arg) {
+    _params: assign.apply(null, [{}, this._params].concat(args.map(function(arg) {
       return ShellCommand.isShellCommand(arg) ? arg._params : {};
     })))
   });
 };
 
-ShellCommand.prototype._quoteArgs = function _quoteArgs (value) {
+ShellCommand.prototype._quoteArgs = function _quoteArgs(value) {
   return ShellCommand.isShellCommand(value) ? value.withParams(this._params).toString() : this._replaceParams(value);
 };
 
-ShellCommand.prototype._replaceParams = function _replaceParams (value) {
-  return value.replace ? value.replace(/\{([^}]+)\}/g, function (whole, name) {
+ShellCommand.prototype._replaceParams = function _replaceParams(value) {
+  return value.replace ? value.replace(/\{([^}]+)\}/g, function(whole, name) {
     return this._params[name] ? this._params[name] : whole;
   }.bind(this)) : value;
 };

--- a/lib/editors/common/terminal.js
+++ b/lib/editors/common/terminal.js
@@ -1,5 +1,8 @@
+var shell = require('./shell');
+var utils = require('../../utils');
+
 var osascript = function(script) {
-  return 'osascript -e \'' + script + '\'';
+  return shell('osascript -e', script);
 };
 
 var terminal = function(cmd) {
@@ -7,20 +10,31 @@ var terminal = function(cmd) {
 };
 
 var runInTerminalDarwin = function(cmd) {
-  return osascript(terminal('cd {projectPath}; ' + cmd));
+  return osascript(terminal(cmd));
 };
 
 var runInTerminalLinux = function(cmd) {
-  return 'gnome-terminal -x sh -c \'sh -c "cd {projectPath}; ' + cmd + '"\'';
+  return shell('gnome-terminal -x sh -c', cmd);
 };
 
-var support = {
+var supported = {
   darwin: runInTerminalDarwin,
   linux: runInTerminalLinux
 }
 
-var runInTerminal = function(cmd) {
-  return support[process.platform](cmd);
+var getTerminal = function(options) {
+  var opts = utils.assign({}, {platform: process.platform}, options || {});
+
+  if (!supported[opts.platform]) {
+    throw new Error('Not supported');
+  }
+
+  return supported[opts.platform];
+}
+
+var runInTerminal = function(cmd, options) {
+  var terminal = getTerminal(options);
+  return terminal(cmd);
 };
 
 module.exports = runInTerminal;

--- a/lib/editors/common/terminal.js
+++ b/lib/editors/common/terminal.js
@@ -23,7 +23,7 @@ var supported = {
 };
 
 var getTerminal = function(options) {
-  var opts = assign({}, {platform: process.platform}, options || {});
+  var opts = assign({platform: process.platform}, options || {});
 
   if (!supported[opts.platform]) {
     throw new Error('Not supported');

--- a/lib/editors/common/terminal.js
+++ b/lib/editors/common/terminal.js
@@ -1,19 +1,19 @@
 var shell = require('./shell');
 var utils = require('../../utils');
 
-var osascript = function (script) {
+var osascript = function(script) {
   return shell('osascript -e', script);
 };
 
-var terminal = function (cmd) {
+var terminal = function(cmd) {
   return 'tell application "Terminal" to do script "' + cmd + '"';
 };
 
-var runInTerminalDarwin = function (cmd) {
+var runInTerminalDarwin = function(cmd) {
   return osascript(terminal(cmd));
 };
 
-var runInTerminalLinux = function (cmd) {
+var runInTerminalLinux = function(cmd) {
   return shell('gnome-terminal -x sh -c', cmd);
 };
 
@@ -22,7 +22,7 @@ var supported = {
   linux: runInTerminalLinux
 };
 
-var getTerminal = function (options) {
+var getTerminal = function(options) {
   var opts = utils.assign({}, {platform: process.platform}, options || {});
 
   if (!supported[opts.platform]) {
@@ -32,7 +32,7 @@ var getTerminal = function (options) {
   return supported[opts.platform];
 };
 
-var runInTerminal = function (cmd, options) {
+var runInTerminal = function(cmd, options) {
   var terminal = getTerminal(options);
   return terminal(cmd);
 };

--- a/lib/editors/common/terminal.js
+++ b/lib/editors/common/terminal.js
@@ -1,5 +1,5 @@
 var shell = require('./shell');
-var utils = require('../../utils');
+var assign = require('../../utils').assign;
 
 var osascript = function(script) {
   return shell('osascript -e', script);
@@ -23,7 +23,7 @@ var supported = {
 };
 
 var getTerminal = function(options) {
-  var opts = utils.assign({}, {platform: process.platform}, options || {});
+  var opts = assign({}, {platform: process.platform}, options || {});
 
   if (!supported[opts.platform]) {
     throw new Error('Not supported');

--- a/lib/editors/common/terminal.js
+++ b/lib/editors/common/terminal.js
@@ -1,28 +1,28 @@
 var shell = require('./shell');
 var utils = require('../../utils');
 
-var osascript = function(script) {
+var osascript = function (script) {
   return shell('osascript -e', script);
 };
 
-var terminal = function(cmd) {
+var terminal = function (cmd) {
   return 'tell application "Terminal" to do script "' + cmd + '"';
 };
 
-var runInTerminalDarwin = function(cmd) {
+var runInTerminalDarwin = function (cmd) {
   return osascript(terminal(cmd));
 };
 
-var runInTerminalLinux = function(cmd) {
+var runInTerminalLinux = function (cmd) {
   return shell('gnome-terminal -x sh -c', cmd);
 };
 
 var supported = {
   darwin: runInTerminalDarwin,
   linux: runInTerminalLinux
-}
+};
 
-var getTerminal = function(options) {
+var getTerminal = function (options) {
   var opts = utils.assign({}, {platform: process.platform}, options || {});
 
   if (!supported[opts.platform]) {
@@ -30,9 +30,9 @@ var getTerminal = function(options) {
   }
 
   return supported[opts.platform];
-}
+};
 
-var runInTerminal = function(cmd, options) {
+var runInTerminal = function (cmd, options) {
   var terminal = getTerminal(options);
   return terminal(cmd);
 };

--- a/lib/editors/common/terminal.js
+++ b/lib/editors/common/terminal.js
@@ -6,8 +6,21 @@ var terminal = function(cmd) {
   return 'tell application "Terminal" to do script "' + cmd + '"';
 };
 
-var runInTerminal = function(cmd) {
+var runInTerminalDarwin = function(cmd) {
   return osascript(terminal('cd {projectPath}; ' + cmd));
+};
+
+var runInTerminalLinux = function(cmd) {
+  return 'gnome-terminal -x sh -c \'sh -c "cd {projectPath}; ' + cmd + '"\'';
+};
+
+var support = {
+  darwin: runInTerminalDarwin,
+  linux: runInTerminalLinux
+}
+
+var runInTerminal = function(cmd) {
+  return support[process.platform](cmd);
 };
 
 module.exports = runInTerminal;

--- a/lib/editors/common/terminal.js
+++ b/lib/editors/common/terminal.js
@@ -2,7 +2,7 @@ var shell = require('./shell');
 var assign = require('../../utils').assign;
 
 var osascript = function(script) {
-  return shell('osascript -e', script);
+  return shell.parse('osascript -e').concat(script);
 };
 
 var terminal = function(cmd) {
@@ -14,7 +14,7 @@ var runInTerminalDarwin = function(cmd) {
 };
 
 var runInTerminalLinux = function(cmd) {
-  return shell('gnome-terminal -x sh -c', cmd);
+  return shell.parse('gnome-terminal -x sh -c', cmd);
 };
 
 var supported = {

--- a/lib/editors/emacs.js
+++ b/lib/editors/emacs.js
@@ -1,12 +1,9 @@
-var runInTerminal = require('./common/terminal');
-
 var settings = {
-  patternOnly: true,
-  escapeQuotes: true,
-  pattern: runInTerminal('emacs --no-splash \\"+{line}:{column}\\" {filename}')
+  executable: 'emacs',
+  pattern: '--no-splash "+{line}:{column}" {filename}'
 };
 
-var detect = require('../detect').platformSupport(['darwin'], 'vim');
+var detect = require('../detect').platformSupport(['darwin', 'linux'], settings.executable);
 var open = require('../open').detectAndOpenFactory(detect, settings);
 
 module.exports = {

--- a/lib/editors/emacs.js
+++ b/lib/editors/emacs.js
@@ -1,9 +1,11 @@
 var settings = {
   executable: 'emacs',
-  pattern: '--no-splash "+{line}:{column}" {filename}'
+  pattern: '--no-splash "+{line}:{column}" {filename}',
+  platforms: ['darwin', 'linux'],
+  terminal: true
 };
 
-var detect = require('../detect').platformSupport(['darwin', 'linux'], settings.executable);
+var detect = require('../detect').platformSupport(settings.platforms, settings.executable);
 var open = require('../open').detectAndOpenFactory(detect, settings);
 
 module.exports = {

--- a/lib/editors/vim.js
+++ b/lib/editors/vim.js
@@ -1,12 +1,13 @@
 var settings = {
   executable: 'vim',
-  // FIXME: enable tabs if vim compiled with the +clientserver option
-  // pattern: '--servername VIM --remote-tab-silent "+call cursor({line}, {column})" {filename}',
+  // enable the tabs if vim compiled with the +clientserver option
+  // pattern: '--servername OE --remote-tab-silent "+call cursor({line}, {column})" {filename}',
   pattern: '"+call cursor({line}, {column})" {filename}',
+  platforms: ['darwin', 'linux'],
   terminal: true
 };
 
-var detect = require('../detect').platformSupport(['darwin', 'linux'], settings.executable);
+var detect = require('../detect').platformSupport(settings.platforms, settings.executable);
 var open = require('../open').detectAndOpenFactory(detect, settings);
 
 module.exports = {

--- a/lib/editors/vim.js
+++ b/lib/editors/vim.js
@@ -1,5 +1,5 @@
 var settings = {
-  binary: 'vim',
+  cmd: 'vim',
   // FIXME: check for vim supports the +clientserver option
   pattern: '--servername VIM --remote-tab-silent "+call cursor({line}, {column})" {filename}',
   terminal: true

--- a/lib/editors/vim.js
+++ b/lib/editors/vim.js
@@ -1,7 +1,8 @@
 var settings = {
   executable: 'vim',
   // FIXME: check for vim supports the +clientserver option
-  pattern: '--servername VIM --remote-tab-silent "+call cursor({line}, {column})" {filename}',
+  // pattern: '--servername VIM --remote-tab-silent "+call cursor({line}, {column})" {filename}',
+  pattern: '"+call cursor({line}, {column})" {filename}',
   terminal: true
 };
 

--- a/lib/editors/vim.js
+++ b/lib/editors/vim.js
@@ -1,11 +1,11 @@
 var settings = {
-  cmd: 'vim',
+  executable: 'vim',
   // FIXME: check for vim supports the +clientserver option
   pattern: '--servername VIM --remote-tab-silent "+call cursor({line}, {column})" {filename}',
   terminal: true
 };
 
-var detect = require('../detect').platformSupport(['darwin', 'linux'], 'vim');
+var detect = require('../detect').platformSupport(['darwin', 'linux'], settings.executable);
 var open = require('../open').detectAndOpenFactory(detect, settings);
 
 module.exports = {

--- a/lib/editors/vim.js
+++ b/lib/editors/vim.js
@@ -1,6 +1,6 @@
 var settings = {
   executable: 'vim',
-  // FIXME: check for vim supports the +clientserver option
+  // FIXME: enable tabs if vim compiled with the +clientserver option
   // pattern: '--servername VIM --remote-tab-silent "+call cursor({line}, {column})" {filename}',
   pattern: '"+call cursor({line}, {column})" {filename}',
   terminal: true

--- a/lib/editors/vim.js
+++ b/lib/editors/vim.js
@@ -1,9 +1,8 @@
-var runInTerminal = require('./common/terminal');
-
 var settings = {
-  patternOnly: true,
-  escapeQuotes: true,
-  pattern: runInTerminal('vim --servername VIM --remote-tab-silent \\"+call cursor({line}, {column})\\" {filename}')
+  binary: 'vim',
+  // FIXME: check for vim supports the +clientserver option
+  pattern: '--servername VIM --remote-tab-silent "+call cursor({line}, {column})" {filename}',
+  terminal: true
 };
 
 var detect = require('../detect').platformSupport(['darwin', 'linux'], 'vim');

--- a/lib/editors/vim.js
+++ b/lib/editors/vim.js
@@ -3,10 +3,10 @@ var runInTerminal = require('./common/terminal');
 var settings = {
   patternOnly: true,
   escapeQuotes: true,
-  pattern: runInTerminal('vim {filename} \\"+call cursor({line}, {column})\\"')
+  pattern: runInTerminal('vim --servername VIM --remote-tab-silent \\"+call cursor({line}, {column})\\" {filename}')
 };
 
-var detect = require('../detect').platformSupport(['darwin'], 'vim');
+var detect = require('../detect').platformSupport(['darwin', 'linux'], 'vim');
 var open = require('../open').detectAndOpenFactory(detect, settings);
 
 module.exports = {

--- a/lib/open.js
+++ b/lib/open.js
@@ -5,7 +5,7 @@ var extractFilename = require('./utils').extractFilename;
 var assign = require('./utils').assign;
 var terminal = require('./editors/common/terminal');
 
-function makeArguments (filename, options) {
+function makeArguments(filename, options) {
   var info = extractFilename(filename);
   var args = {
     filename: info.filename,
@@ -17,7 +17,7 @@ function makeArguments (filename, options) {
   return args;
 }
 
-function makeCommand (cmd, filename, settings) {
+function makeCommand(cmd, filename, settings) {
   var defaultOptions = {
     pattern: '{filename}:{line}:{column}',
     projectPath: process.env.PROJECT_PATH || process.PWD || process.cwd(),
@@ -35,10 +35,10 @@ function makeCommand (cmd, filename, settings) {
   return { cmd: '' + command.withParams(args), cwd: options.projectPath };
 }
 
-function open (cmd, filename, settings) {
-  return new Promise(function (resolve, reject) {
+function open(cmd, filename, settings) {
+  return new Promise(function(resolve, reject) {
     var command = makeCommand(cmd, filename, settings);
-    exec(command.cmd, { cwd: command.cwd }, function (err) {
+    exec(command.cmd, { cwd: command.cwd }, function(err) {
       if (err) {
         reject(err);
       } else {
@@ -51,14 +51,14 @@ function open (cmd, filename, settings) {
 module.exports = open;
 module.exports = assign(module.exports, {
   makeCommand: makeCommand,
-  factory: function (cmd, settings) {
-    return function openInEditor (filename) {
+  factory: function(cmd, settings) {
+    return function openInEditor(filename) {
       return open(cmd, filename, settings);
     };
   },
-  detectAndOpenFactory: function (detect, settings) {
-    return function openInEditor (filename) {
-      return detect().then(function (cmd) {
+  detectAndOpenFactory: function(detect, settings) {
+    return function openInEditor(filename) {
+      return detect().then(function(cmd) {
         return open(cmd, filename, settings);
       });
     };

--- a/lib/open.js
+++ b/lib/open.js
@@ -5,53 +5,40 @@ var extractFilename = require('./utils').extractFilename;
 var assign = require('./utils').assign;
 var terminal = require('./editors/common/terminal');
 
-
-function getShellPattern(settings) {
-  var pattern = settings.pattern || '';
-
-  if (typeof pattern === 'string') {
-    pattern = shell(pattern);
-  }
-
-  if (!/\{filename\}/.test('' + pattern)) {
-    pattern = pattern.concat('{filename}:{line}:{column}');
-  }
-
-  return pattern;
-}
-
-function makeArguments(filename, settings, projectPath) {
+function makeArguments (filename, options) {
   var info = extractFilename(filename);
-
-  var values = {
-    projectPath: settings.projectPath,
-    line: info.line + number(settings.line, 1),
-    column: info.column + number(settings.column, 1),
-    filename: info.filename
+  var args = {
+    filename: info.filename,
+    line: info.line + number(options.line, 1),
+    column: info.column + number(options.column, 1),
+    projectPath: options.projectPath
   };
 
-  return values;
+  return args;
 }
 
-function open(cmd, filename, settings) {
-  return new Promise(function(resolve, reject) {
-    var projectPath = process.env.PROJECT_PATH || process.PWD || process.cwd();
-    var options = assign({}, {
-      binary: cmd || settings.binary,
-      projectPath: projectPath,
-      terminal: false
-    }, settings);
+function makeCommand (cmd, filename, settings) {
+  var defaultOptions = {
+    pattern: '{filename}:{line}:{column}',
+    projectPath: process.env.PROJECT_PATH || process.PWD || process.cwd(),
+    terminal: false
+  };
+  var cmdOptions = cmd ? { cmd: cmd } : {};
+  var options = assign({}, defaultOptions, settings, cmdOptions);
+  var command, args;
 
-    var args = makeArguments(filename, options, projectPath);
-    var pattern = getShellPattern(options);
-    var command = (options.patternOnly ? pattern : shell(options.binary).concat(pattern)).withParams(args);
-    if (options.terminal) {
-      command = terminal(command);
-    }
+  command = options.patternOnly ? shell(options.pattern) : shell(options.cmd).concat(options.pattern);
+  if (options.terminal) {
+    command = terminal(command, options);
+  }
+  args = makeArguments(filename, options);
+  return { cmd: '' + command.withParams(args), cwd: options.projectPath };
+}
 
-    var script = '' + command;
-    console.log(script);
-    exec(script, {cwd: projectPath}, function(err) {
+function open (cmd, filename, settings) {
+  return new Promise(function (resolve, reject) {
+    var command = makeCommand(cmd, filename, settings);
+    exec(command.cmd, { cwd: command.cwd }, function (err) {
       if (err) {
         reject(err);
       } else {
@@ -62,16 +49,18 @@ function open(cmd, filename, settings) {
 }
 
 module.exports = open;
-module.exports.factory = function(cmd, settings) {
-  return function openInEditor(filename) {
-    return open(cmd, filename, settings);
-  };
-};
-
-module.exports.detectAndOpenFactory = function(detect, settings) {
-  return function openInEditor(filename) {
-    return detect().then(function(cmd) {
-      open(cmd, filename, settings);
-    });
-  };
-};
+module.exports = assign(module.exports, {
+  makeCommand: makeCommand,
+  factory: function (cmd, settings) {
+    return function openInEditor (filename) {
+      return open(cmd, filename, settings);
+    };
+  },
+  detectAndOpenFactory: function (detect, settings) {
+    return function openInEditor (filename) {
+      return detect().then(function (cmd) {
+        return open(cmd, filename, settings);
+      });
+    };
+  }
+});

--- a/lib/open.js
+++ b/lib/open.js
@@ -1,53 +1,57 @@
 var exec = require('child_process').exec;
 var number = require('./utils').number;
-var quote = require('./utils').quote;
+var shell = require('./editors/common/shell');
 var extractFilename = require('./utils').extractFilename;
-var append = require('./utils').append;
+var assign = require('./utils').assign;
+var terminal = require('./editors/common/terminal');
 
-function makeArguments(filename, settings) {
-  var info = extractFilename(filename);
+
+function getShellPattern(settings) {
   var pattern = settings.pattern || '';
-  var values = {
-    projectPath: process.env.PROJECT_PATH || process.PWD || process.cwd(),
-    line: info.line + number(settings.line, 1),
-    column: info.column + number(settings.column, 1)
-  };
 
-  if (!/\{filename\}/.test(pattern)) {
-    pattern = append(pattern, '{filename}:{line}:{column}');
+  if (typeof pattern === 'string') {
+    pattern = shell(pattern);
   }
 
-  return pattern
-    .replace(
-      new RegExp('\\{(' + Object.keys(values).join('|') + ')\\}', 'g'),
-      function(m, name) {
-        return values[name];
-      }
-    )
-    // replace `{filename}` and adjoined right string for quoted filename,
-    // since filename can have spaces
-    //
-    //   {filename} --line 1 --column 2
-    //   => "filename" --line 1 --column 2
-    //
-    //   {filename}:1:2
-    //   => "filename:1:2"
-    //
-    .replace(/\{filename\}(\S*)/, function(m, rest) {
-      return quote(info.filename, settings.escapeQuotes) + rest;
-    });
+  if (!/\{filename\}/.test('' + pattern)) {
+    pattern = pattern.concat('{filename}:{line}:{column}');
+  }
+
+  return pattern;
+}
+
+function makeArguments(filename, settings, projectPath) {
+  var info = extractFilename(filename);
+
+  var values = {
+    projectPath: settings.projectPath,
+    line: info.line + number(settings.line, 1),
+    column: info.column + number(settings.column, 1),
+    filename: info.filename
+  };
+
+  return values;
 }
 
 function open(cmd, filename, settings) {
   return new Promise(function(resolve, reject) {
-    var args;
+    var projectPath = process.env.PROJECT_PATH || process.PWD || process.cwd();
+    var options = assign({}, {
+      binary: cmd || settings.binary,
+      projectPath: projectPath,
+      terminal: false
+    }, settings);
 
-    settings = settings || {};
-    args = makeArguments(filename, settings);
-    cmd = settings.patternOnly ? args : append(quote(cmd), args);
+    var args = makeArguments(filename, options, projectPath);
+    var pattern = getShellPattern(options);
+    var command = (options.patternOnly ? pattern : shell(options.binary).concat(pattern)).withParams(args);
+    if (options.terminal) {
+      command = terminal(command);
+    }
 
-    console.log(cmd);
-    exec(cmd, function(err) {
+    var script = '' + command;
+    console.log(script);
+    exec(script, {cwd: projectPath}, function(err) {
       if (err) {
         reject(err);
       } else {

--- a/lib/open.js
+++ b/lib/open.js
@@ -5,18 +5,6 @@ var extractFilename = require('./utils').extractFilename;
 var assign = require('./utils').assign;
 var terminal = require('./editors/common/terminal');
 
-function makeArguments(filename, options) {
-  var info = extractFilename(filename);
-  var args = {
-    filename: info.filename,
-    line: info.line + number(options.line, 1),
-    column: info.column + number(options.column, 1),
-    projectPath: options.projectPath
-  };
-
-  return args;
-}
-
 function makeCommand(cmd, filename, settings) {
   var defaultOptions = {
     pattern: '{filename}:{line}:{column}',
@@ -24,15 +12,22 @@ function makeCommand(cmd, filename, settings) {
     terminal: false
   };
   var cmdOptions = cmd ? { cmd: cmd } : {};
-  var options = assign({}, defaultOptions, settings, cmdOptions);
-  var command, args;
-
-  command = options.patternOnly ? shell(options.pattern) : shell(options.cmd || options.executable).concat(options.pattern);
+  var options = assign(defaultOptions, settings, cmdOptions);
+  var command = shell(options.cmd || options.executable).concat(options.pattern);
+  var info = extractFilename(filename);
+  var args = {
+    filename: info.filename,
+    line: info.line + number(options.line, 1),
+    column: info.column + number(options.column, 1),
+    projectPath: options.projectPath
+  };
   if (options.terminal) {
     command = terminal(command, options);
   }
-  args = makeArguments(filename, options);
-  return { cmd: '' + command.withParams(args), cwd: options.projectPath };
+  return {
+    cmd: command.withParams(args).toString(),
+    cwd: options.projectPath
+  };
 }
 
 function open(cmd, filename, settings) {

--- a/lib/open.js
+++ b/lib/open.js
@@ -34,7 +34,7 @@ function makeArguments(filename, settings) {
     //   => "filename:1:2"
     //
     .replace(/\{filename\}(\S*)/, function(m, rest) {
-      return quote(info.filename + rest, settings.escapeQuotes);
+      return quote(info.filename, settings.escapeQuotes) + rest;
     });
 }
 
@@ -46,6 +46,7 @@ function open(cmd, filename, settings) {
     args = makeArguments(filename, settings);
     cmd = settings.patternOnly ? args : append(quote(cmd), args);
 
+    console.log(cmd);
     exec(cmd, function(err) {
       if (err) {
         reject(err);

--- a/lib/open.js
+++ b/lib/open.js
@@ -13,7 +13,7 @@ function makeCommand(cmd, filename, settings) {
   };
   var cmdOptions = cmd ? { cmd: cmd } : {};
   var options = assign(defaultOptions, settings, cmdOptions);
-  var command = shell(options.cmd || options.executable).concat(options.pattern);
+  var command = shell(options.cmd || options.executable).concat(shell.parse(options.pattern));
   var info = extractFilename(filename);
   var args = {
     filename: info.filename,
@@ -25,7 +25,7 @@ function makeCommand(cmd, filename, settings) {
     command = terminal(command, options);
   }
   return {
-    cmd: command.withParams(args).toString(),
+    cmd: String(command.withParams(args)),
     cwd: options.projectPath
   };
 }

--- a/lib/open.js
+++ b/lib/open.js
@@ -27,7 +27,7 @@ function makeCommand (cmd, filename, settings) {
   var options = assign({}, defaultOptions, settings, cmdOptions);
   var command, args;
 
-  command = options.patternOnly ? shell(options.pattern) : shell(options.cmd).concat(options.pattern);
+  command = options.patternOnly ? shell(options.pattern) : shell(options.cmd || options.executable).concat(options.pattern);
   if (options.terminal) {
     command = terminal(command, options);
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -41,17 +41,14 @@ module.exports = {
   append: function(str, appendix) {
     return String(str).replace(/\s*$/, (str ? ' ' : '') + appendix);
   },
-  assign: function(/* dest, src1, src2, src */) {
-    var args = (arguments.length === 1 ? [arguments[0]] : Array.apply(null, arguments));
-
-    return args.reduce(function(dest, src) {
+  assign: function(dest/*, ...sources */) {
+    return Array.prototype.slice.call(arguments, 1).reduce(function(dest, src) {
       for (var key in src) {
         if (Object.prototype.hasOwnProperty.call(src, key)) {
           dest[key] = src[key];
         }
       }
-
       return dest;
-    });
+    }, dest);
   }
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,15 +5,6 @@ module.exports = {
   number: function(value, fallback) {
     return isNaN(value) ? fallback : value;
   },
-  quote: function(value, escapeQuotes) {
-    value = String(value)
-      .replace(/\\/g, '\\\\')
-      .replace(/"/g, '\"');
-
-    return escapeQuotes
-      ? '\\"' + value + '\\"'
-      : '"' + value + '"';
-  },
   extractFilename: function(filename) {
     var parts = filename.match(/^(.+?)((?::\d+){0,4})$/);
     var segment = parts[2].split(':').slice(1);
@@ -50,7 +41,9 @@ module.exports = {
   append: function(str, appendix) {
     return String(str).replace(/\s*$/, (str ? ' ' : '') + appendix);
   },
-  assign: function(...args) {
+  assign: function(/* dest, src1, src2, src */) {
+    var args = (arguments.length === 1 ? [arguments[0]] : Array.apply(null, arguments));
+
     return args.reduce(function(dest, src) {
       for (var key in src) {
         if (Object.prototype.hasOwnProperty.call(src, key)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -50,13 +50,15 @@ module.exports = {
   append: function(str, appendix) {
     return String(str).replace(/\s*$/, (str ? ' ' : '') + appendix);
   },
-  assign: function(dest, src) {
-    for (var key in src) {
-      if (Object.prototype.hasOwnProperty.call(src, key)) {
-        dest[key] = src[key];
+  assign: function(...args) {
+    return args.reduce(function(dest, src) {
+      for (var key in src) {
+        if (Object.prototype.hasOwnProperty.call(src, key)) {
+          dest[key] = src[key];
+        }
       }
-    }
 
-    return dest;
+      return dest;
+    });
   }
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,9 +10,9 @@ module.exports = {
       .replace(/\\/g, '\\\\')
       .replace(/"/g, '\"');
 
-    return escapeQuotes ?
-      '\\"' + value + '\\"' :
-      '"' + value + '"';
+    return escapeQuotes
+      ? '\\"' + value + '\\"'
+      : '"' + value + '"';
   },
   extractFilename: function(filename) {
     var parts = filename.match(/^(.+?)((?::\d+){0,4})$/);
@@ -34,7 +34,7 @@ module.exports = {
   any: function(promises, err) {
     return new Promise(function(resolve, reject) {
       Promise.all(promises.map(function(item) {
-        if (item && typeof item.then == 'function') {
+        if (item && typeof item.then === 'function') {
           return item.then(
             resolve,    // any success resolves the main promise immediately
             function() { /* ignore any reject */ }

--- a/package.json
+++ b/package.json
@@ -34,8 +34,6 @@
     "shell-quote": "1.6.1"
   },
   "devDependencies": {
-    "chai": "3.5.0",
-    "dirty-chai": "1.2.2",
     "eslint": "3.18.0",
     "eslint-config-semistandard": "8.0.0",
     "eslint-config-standard": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "lint": "eslint --ext js .",
     "fix": "eslint --fix --ext js .",
-    "test": "mocha --reporter spec --bail --check-leaks test/",
-    "test-watch": "mocha -w --reporter spec --bail --check-leaks test/"
+    "test": "mocha --reporter spec --bail --check-leaks test",
+    "test-watch": "mocha -w --reporter spec --bail --check-leaks test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,11 @@
     "clap": "^1.1.3",
     "os-homedir": "~1.0.2"
   },
-  "devDependencies": {},
-  "scripts": {}
+  "devDependencies": {
+    "mocha": "3.2.0"
+  },
+  "scripts": {
+    "test": "mocha --reporter spec --bail --check-leaks test/",
+    "test-watch": "mocha -w --reporter spec --bail --check-leaks test/"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   "devDependencies": {
     "chai": "3.5.0",
     "dirty-chai": "1.2.2",
-    "eslint": "3.15.0",
-    "eslint-config-semistandard": "7.0.0",
-    "eslint-config-standard": "7.0.0",
+    "eslint": "3.18.0",
+    "eslint-config-semistandard": "8.0.0",
+    "eslint-config-standard": "7.1.0",
     "eslint-mocha": "0.1.0",
     "eslint-plugin-mocha": "4.9.0",
     "eslint-plugin-promise": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,12 @@
   },
   "dependencies": {
     "clap": "^1.1.3",
-    "os-homedir": "~1.0.2"
+    "command-join": "2.0.0",
+    "os-homedir": "~1.0.2",
+    "shell-quote": "1.6.1"
   },
   "devDependencies": {
+    "chai": "3.5.0",
     "mocha": "3.2.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,20 @@
   },
   "devDependencies": {
     "chai": "3.5.0",
+    "dirty-chai": "1.2.2",
+    "eslint": "3.15.0",
+    "eslint-config-semistandard": "7.0.0",
+    "eslint-config-standard": "7.0.0",
+    "eslint-mocha": "0.1.0",
+    "eslint-plugin-markdown": "1.0.0-beta.4",
+    "eslint-plugin-mocha": "4.9.0",
+    "eslint-plugin-promise": "3.5.0",
+    "eslint-plugin-standard": "2.1.1",
     "mocha": "3.2.0"
   },
   "scripts": {
+    "lint": "eslint --ext js .",
+    "fix": "eslint --fix --ext js .",
     "test": "mocha --reporter spec --bail --check-leaks test/",
     "test-watch": "mocha -w --reporter spec --bail --check-leaks test/"
   }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "eslint-config-semistandard": "7.0.0",
     "eslint-config-standard": "7.0.0",
     "eslint-mocha": "0.1.0",
-    "eslint-plugin-markdown": "1.0.0-beta.4",
     "eslint-plugin-mocha": "4.9.0",
     "eslint-plugin-promise": "3.5.0",
     "eslint-plugin-standard": "2.1.1",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "extends": "semistandard",
+  "env": {
+    "mocha": true
+  }
+}

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,6 +1,12 @@
 {
   "extends": "semistandard",
+  "plugins": [
+    "mocha"
+  ],
   "env": {
     "mocha": true
+  },
+  "rules": {
+    "mocha/no-exclusive-tests": "error"
   }
 }

--- a/test/open.spec.js
+++ b/test/open.spec.js
@@ -1,42 +1,38 @@
-var chai = require('chai');
-var expect = chai.expect;
-
-chai.use(require('dirty-chai'));
-
+var assert = require('assert');
 var makeCommand = require('../lib/open').makeCommand;
 
 describe('makeCommand', function () {
   it('should exits', function () {
-    expect(makeCommand).to.be.ok();
+    assert.ok(makeCommand);
   });
 
   it('should return cmd', function () {
     var res = makeCommand('vim', 'test.txt:1:1');
-    expect(res.cmd).to.be.ok();
+    assert.ok(res.cmd);
   });
 
   it('should return cwd', function () {
     var res = makeCommand('vim', 'test.txt:1:1');
-    expect(res.cwd).to.be.ok();
+    assert.ok(res.cwd);
   });
 
   it('should create editor command', function () {
     var res = makeCommand('editor', 'test.txt:1:1');
-    expect(res.cmd).to.be.equal('editor test.txt:2:2');
+    assert.equal(res.cmd, 'editor test.txt:2:2');
   });
 
   it('should support `projectPath` option', function () {
     var res = makeCommand('editor', 'test.txt:1:1', { projectPath: '/root' });
-    expect(res.cwd).to.be.equal('/root');
+    assert.equal(res.cwd, '/root');
   });
 
   it('should support `terminal` option for linux', function () {
     var res = makeCommand('editor', 'test.txt:1:1', { terminal: true, platform: 'linux' });
-    expect(res.cmd).to.be.match(/gnome-terminal/);
+    assert.ok(res.cmd.match(/gnome-terminal/));
   });
 
   it('should support `terminal` option for darwin', function () {
     var res = makeCommand('editor', 'test.txt:1:1', { terminal: true, platform: 'darwin' });
-    expect(res.cmd).to.be.match(/osascript/);
+    assert.ok(res.cmd.match(/osascript/));
   });
 });

--- a/test/open.spec.js
+++ b/test/open.spec.js
@@ -1,0 +1,42 @@
+var chai = require('chai');
+var expect = chai.expect;
+
+chai.use(require('dirty-chai'));
+
+var makeCommand = require('../lib/open').makeCommand;
+
+describe('makeCommand', function () {
+  it('should exits', function () {
+    expect(makeCommand).to.be.ok();
+  });
+
+  it('should return cmd', function () {
+    var res = makeCommand('vim', 'test.txt:1:1');
+    expect(res.cmd).to.be.ok();
+  });
+
+  it('should return cwd', function () {
+    var res = makeCommand('vim', 'test.txt:1:1');
+    expect(res.cwd).to.be.ok();
+  });
+
+  it('should create editor command', function () {
+    var res = makeCommand('editor', 'test.txt:1:1');
+    expect(res.cmd).to.be.equal('editor test.txt:2:2');
+  });
+
+  it('should support `projectPath` option', function () {
+    var res = makeCommand('editor', 'test.txt:1:1', { projectPath: '/root' });
+    expect(res.cwd).to.be.equal('/root');
+  });
+
+  it('should support `terminal` option for linux', function () {
+    var res = makeCommand('editor', 'test.txt:1:1', { terminal: true, platform: 'linux' });
+    expect(res.cmd).to.be.match(/gnome-terminal/);
+  });
+
+  it('should support `terminal` option for darwin', function () {
+    var res = makeCommand('editor', 'test.txt:1:1', { terminal: true, platform: 'darwin' });
+    expect(res.cmd).to.be.match(/osascript/);
+  });
+});

--- a/test/open.spec.js
+++ b/test/open.spec.js
@@ -28,11 +28,11 @@ describe('makeCommand', function () {
 
   it('should support `terminal` option for linux', function () {
     var res = makeCommand('editor', 'test.txt:1:1', { terminal: true, platform: 'linux' });
-    assert.ok(res.cmd.match(/gnome-terminal/));
+    assert.ok(res.cmd.match(/^gnome-terminal/));
   });
 
   it('should support `terminal` option for darwin', function () {
     var res = makeCommand('editor', 'test.txt:1:1', { terminal: true, platform: 'darwin' });
-    assert.ok(res.cmd.match(/osascript/));
+    assert.ok(res.cmd.match(/^osascript/));
   });
 });

--- a/test/shell.spec.js
+++ b/test/shell.spec.js
@@ -1,86 +1,98 @@
-var chai = require('chai');
-var expect = chai.expect;
-
+var assert = require('assert');
 var shell = require('../lib/editors/common/shell');
 
 describe('shell command', function () {
   it('should take zero argument', function () {
-    expect(shell() + '')
-      .to.equal('');
+    var res = shell();
+    assert.equal(res, '');
   });
 
   it('should take single argument', function () {
-    expect(shell('sh') + '')
-      .to.equal('sh');
+    var res = shell('sh');
+    assert.equal(res, 'sh');
   });
 
   it('should take many arguments', function () {
-    expect(shell('sh -c') + '')
-      .to.equal('sh -c');
+    var res = shell('sh -c');
+    assert.equal(res, 'sh -c');
   });
 
   it('should take nested shell', function () {
-    expect(shell('sh -c', shell('bash')) + '')
-      .to.equal('sh -c bash');
+    var res = shell('sh -c', shell('bash'));
+    assert.equal(res, 'sh -c bash');
   });
 
   it('should take nested shell with many arguments', function () {
-    expect(shell('sh -c', shell('echo foo')) + '')
-      .to.equal(`sh -c 'echo foo'`);
+    var res = shell('sh -c', shell('echo foo'));
+    assert.equal(res, "sh -c 'echo foo'");
   });
 
   it('should take nested shell with arbitrary levels', function () {
-    expect(shell('sh -c', shell('sh -c', shell('echo foo'))) + '')
-      .to.equal(`sh -c 'sh -c '\\''echo foo'\\'`);
+    var res = shell('sh -c', shell('sh -c', shell('echo foo')));
+    assert.equal(res, "sh -c 'sh -c '\\''echo foo'\\'");
   });
 
   it('should substitute single param', function () {
-    expect(shell('sh -c {path}').withParams({ path: 'foo' }) + '')
-      .to.equal('sh -c foo');
+    var res = shell('sh -c {path}').withParams({
+      path: 'foo'
+    });
+    assert.equal(res, 'sh -c foo');
   });
 
   it('should substitute param inside the argument', function () {
-    expect(shell('sh -c {path}:1').withParams({ path: 'foo', line: 1 }) + '')
-      .to.equal(`sh -c foo:1`);
+    var res = shell('sh -c {path}:1').withParams({
+      path: 'foo',
+      line: 1
+    });
+    assert.equal(res, 'sh -c foo:1');
   });
 
   it('should substitute param having some spaces in value', function () {
-    expect(shell('sh -c {path}:1').withParams({ path: 'foo bar', line: 1 }) + '')
-      .to.equal(`sh -c 'foo bar:1'`);
+    var res = shell('sh -c {path}:1').withParams({
+      path: 'foo bar',
+      line: 1
+    });
+    assert.equal(res, "sh -c 'foo bar:1'");
   });
 
   it('should propagate params to nested shells', function () {
-    expect(shell('sh -c', shell('{path}')).withParams({ path: 'foo' }) + '')
-      .to.equal('sh -c foo');
+    var res = shell('sh -c', shell('{path}')).withParams({
+      path: 'foo'
+    });
+    assert.equal(res, 'sh -c foo');
   });
 
   it('should propagete params having some spaces in value to nested shells', function () {
-    expect(shell('sh -c', shell('echo {path}')).withParams({ path: 'foo bar' }) + '')
-      .to.equal(`sh -c 'echo '\\''foo bar'\\'`);
+    var res = shell('sh -c', shell('echo {path}')).withParams({
+      path: 'foo bar'
+    });
+    assert.equal(res, "sh -c 'echo '\\''foo bar'\\'");
   });
 
   it('should keep unparsed params', function () {
-    expect(shell('cd {projectDir}') + '')
-      .to.equal(`cd {projectDir}`);
+    var res = shell('cd {projectDir}');
+    assert.equal(res, 'cd {projectDir}');
   });
 
   it('should keep multiple unparsed params', function () {
-    expect(shell('cd {projectDir} {line}') + '')
-      .to.equal(`cd {projectDir} {line}`);
+    var res = shell('cd {projectDir} {line}');
+    assert.equal(res, 'cd {projectDir} {line}');
   });
 
   it('should append agruments', function () {
-    expect(shell('sh').concat('-c -d') + '')
-      .to.equal(`sh -c -d`);
+    var res = shell('sh').concat('-c -d');
+    assert.equal(res, 'sh -c -d');
   });
 
   it('should concat shell', function () {
-    expect(shell('sh').concat(shell('-c -d')) + '')
-      .to.equal(`sh -c -d`);
+    var res = shell('sh').concat(shell('-c -d'));
+    assert.equal(res, 'sh -c -d');
   });
 
   it('should concat shell with params', function () {
-    expect(shell('sh').concat(shell('{foo}').withParams({foo: 'bar'})) + '')
-      .to.equal(`sh bar`);
+    var res = shell('sh').concat(shell('{foo}').withParams({
+      foo: 'bar'
+    }));
+    assert.equal(res, 'sh bar');
   });
 });

--- a/test/shell.spec.js
+++ b/test/shell.spec.js
@@ -1,5 +1,6 @@
-// var terminal = require('../lib/editors/common/terminal');
-var expect = require('chai').expect;
+var chai = require('chai');
+var expect = chai.expect;
+
 var shell = require('../lib/editors/common/shell');
 
 describe('shell command', function () {

--- a/test/shell.spec.js
+++ b/test/shell.spec.js
@@ -8,6 +8,7 @@ describe('shell command', function () {
     expect(shell() + '')
       .to.equal('');
   });
+
   it('should take single argument', function () {
     expect(shell('sh') + '')
       .to.equal('sh');

--- a/test/test_shell.js
+++ b/test/test_shell.js
@@ -1,0 +1,84 @@
+// var terminal = require('../lib/editors/common/terminal');
+var expect = require('chai').expect;
+var shell = require('../lib/editors/common/shell');
+
+describe('shell command', function () {
+  it('should take zero argument', function () {
+    expect(shell() + '')
+      .to.equal('');
+  });
+  it('should take single argument', function () {
+    expect(shell('sh') + '')
+      .to.equal('sh');
+  });
+
+  it('should take many arguments', function () {
+    expect(shell('sh -c') + '')
+      .to.equal('sh -c');
+  });
+
+  it('should take nested shell', function () {
+    expect(shell('sh -c', shell('bash')) + '')
+      .to.equal('sh -c bash');
+  });
+
+  it('should take nested shell with many arguments', function () {
+    expect(shell('sh -c', shell('echo foo')) + '')
+      .to.equal(`sh -c 'echo foo'`);
+  });
+
+  it('should take nested shell with arbitrary levels', function () {
+    expect(shell('sh -c', shell('sh -c', shell('echo foo'))) + '')
+      .to.equal(`sh -c 'sh -c '\\''echo foo'\\'`);
+  });
+
+  it('should substitute single param', function () {
+    expect(shell('sh -c {path}').withParams({ path: 'foo' }) + '')
+      .to.equal('sh -c foo');
+  });
+
+  it('should substitute param inside the argument', function () {
+    expect(shell('sh -c {path}:1').withParams({ path: 'foo', line: 1 }) + '')
+      .to.equal(`sh -c foo:1`);
+  });
+
+  it('should substitute param having some spaces in value', function () {
+    expect(shell('sh -c {path}:1').withParams({ path: 'foo bar', line: 1 }) + '')
+      .to.equal(`sh -c 'foo bar:1'`);
+  });
+
+  it('should propagate params to nested shells', function () {
+    expect(shell('sh -c', shell('{path}')).withParams({ path: 'foo' }) + '')
+      .to.equal('sh -c foo');
+  });
+
+  it('should propagete params having some spaces in value to nested shells', function () {
+    expect(shell('sh -c', shell('echo {path}')).withParams({ path: 'foo bar' }) + '')
+      .to.equal(`sh -c 'echo '\\''foo bar'\\'`);
+  });
+
+  it('should keep unparsed params', function () {
+    expect(shell('cd {projectDir}') + '')
+      .to.equal(`cd {projectDir}`);
+  });
+
+  it('should keep multiple unparsed params', function () {
+    expect(shell('cd {projectDir} {line}') + '')
+      .to.equal(`cd {projectDir} {line}`);
+  });
+
+  it('should append agruments', function () {
+    expect(shell('sh').concat('-c -d') + '')
+      .to.equal(`sh -c -d`);
+  });
+
+  it('should concat shell', function () {
+    expect(shell('sh').concat(shell('-c -d')) + '')
+      .to.equal(`sh -c -d`);
+  });
+
+  it('should concat shell with params', function () {
+    expect(shell('sh').concat(shell('{foo}').withParams({foo: 'bar'})) + '')
+      .to.equal(`sh bar`);
+  });
+});


### PR DESCRIPTION
Added the `gnome-terminal` to the terminal.js for `linux` platform.
Added `--servername VIM --remote-tab-silent` agruments to the `vim`. So it can open files in the single instance using tabs. 
Fixed a little bug in the `{filename}` quoting function.

Still trying to find a solution how to bring to the front a terminal window with the vim when it's already opened.
Also I'm a little bit worried about the quoting of the command line agruments. An 'gnome-terminal -> sh -> vim' escaping pipe is hardcoded and looks terrible now. So it seems can be unsafe.