### PR TITLE
fix(makeArguments): No correct work if editor is emacs.

### DIFF
--- a/lib/open.js
+++ b/lib/open.js
@@ -33,7 +33,7 @@ function makeArguments(filename, settings) {
     //   {filename}:1:2
     //   => "filename:1:2"
     //
-    .replace(/\{filename\}(\S*)/, function(m, rest) {
+    .replace(/\{filename\}([^\\'"]*)/, function(m, rest) {
       return quote(info.filename + rest, settings.escapeQuotes);
     });
 }

--- a/lib/open.js
+++ b/lib/open.js
@@ -33,7 +33,7 @@ function makeArguments(filename, settings) {
     //   {filename}:1:2
     //   => "filename:1:2"
     //
-    .replace(/\{filename\}([^\\'"]*)/, function(m, rest) {
+    .replace(/\{filename\}([^\\'"\s]*)/, function(m, rest) {
       return quote(info.filename + rest, settings.escapeQuotes);
     });
 }


### PR DESCRIPTION
@lahmatiy 
reference:
["aws amplify add" bombs on macOS with quote problem if editor is emacs #1246](https://github.com/aws-amplify/amplify-cli/issues/1246)
